### PR TITLE
Revert "Add codespell to the linting process"

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -20,12 +20,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install codespell flake8 isort yapf
+        pip install flake8 yapf isort
 
     # modify the folders accordingly
     - name: Lint
       run: |
-        codespell
         flake8 .
         isort --check-only --diff basicsr/ options/ scripts/ tests/ inference/ setup.py
         yapf -r -d basicsr/ options/ scripts/ tests/ inference/ setup.py


### PR DESCRIPTION
Reverts xinntao/ProjectTemplate-Python#1

As codespell introduces unnecessary checks for beginners (such as we may need to take care of the ignore-words-lists) and this template aims to provide an easy start for beginners, so we remove codespell checks in this template. 

We will add codespell once the projects are ready for publication, such as BasicSR, Real-ESRGAN, GFPGAN, facexlib, etc